### PR TITLE
Move fail2ban vars to [all]

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -163,3 +163,7 @@ firewalld_services:
 - service: http
 - service: https
 - service: ssh
+
+# fail2ban vars
+fail2ban_failregex: '^<HOST>.*/catalog/bib_.*$'
+fail2ban_logpath:   "/var/log/httpd/catalyst-ssl-access.log"

--- a/inventory/group_vars/dev/vars.yml
+++ b/inventory/group_vars/dev/vars.yml
@@ -63,7 +63,3 @@ findit_ip:               "10.11.12.102" # not really
 # NOTE: this is important to do at least once, as we are using some of
 # firewall-cmd's recently added capabilities
 firewalld_update_packages:  true
-
-# fail2ban vars
-fail2ban_failregex: '^<HOST>.*/catalog/bib_.*$'
-fail2ban_logpath:   "/var/log/httpd/catalyst-ssl-access.log"


### PR DESCRIPTION
Now that fail2ban is deployed to (almost) all environments, with the same configs, may as well have the vars in [all]